### PR TITLE
fix scihub-cc not found problem

### DIFF
--- a/scihub2pdf/download.py
+++ b/scihub2pdf/download.py
@@ -39,7 +39,7 @@ xpath_captcha = "//*[@id='captcha']"
 xpath_pdf = "//*[@id='pdf']"
 xpath_input = "/html/body/div/table/tbody/tr/td/form/input"
 xpath_form = "/html/body/div/table/tbody/tr/td/form"
-domain_scihub = "http://sci-hub.cc/"
+domain_scihub = "http://80.82.77.83/"
 
 ScrapSci = SciHub(headers,
                   xpath_captcha,

--- a/scihub2pdf/scihub.py
+++ b/scihub2pdf/scihub.py
@@ -23,7 +23,7 @@ class SciHub(object):
                  xpath_pdf="//*[@id='pdf']",
                  xpath_input="/html/body/div/table/tbody/tr/td/form/input",
                  xpath_form="/html/body/div/table/tbody/tr/td/form",
-                 domain_scihub="http://sci-hub.cc/",
+                 domain_scihub="http://80.82.77.83/",
                  ):
 
         self.xpath_captcha = xpath_captcha


### PR DESCRIPTION
Since the sci-hub.cc has been blocked, it's a good idea to use its IP address instead of the initial domain. I have tested it and all work well. What's more, I believe adding some support for searching new sci-hub domains could be a good way also.